### PR TITLE
Fixing dependency download

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,8 @@ jobs:
           cache: maven
 
       - name: Build and test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
           ./mvnw --batch-mode --update-snapshots verify
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,29 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
           cache: maven
 
-      - name: Configure Nexus credentials
-        uses: s4u/maven-settings-action@v2.6.0
-        with:
-          servers: |
-            [
-              {"id": "mhikes-snapshots", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"},
-              {"id": "mhikes-releases", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"}
-            ]
+      - name: Configure package repository credentials
+        uses: s4u/maven-settings-action@v3.1.0
 
       - name: Build and test
         run: >
-          mvn -B -U verify
+          ./mvnw --batch-mode --update-snapshots verify
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: built-jars
           path: "**/target/*.jar"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,14 +17,19 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          server-id: github
+          server-username: MAVEN_USER
+          server-password: MAVEN_TOKEN
           distribution: temurin
           java-version: ${{ inputs.java-version }}
           cache: maven
 
       - name: Build and test
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
+        env: 
+          MAVEN_USER: ${{ vars.MAVEN_USER }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+        run: |
+          cat ~/.m2/settings.xml
           ./mvnw --batch-mode --update-snapshots verify
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,9 +21,6 @@ jobs:
           java-version: ${{ inputs.java-version }}
           cache: maven
 
-      - name: Configure package repository credentials
-        uses: s4u/maven-settings-action@v3.1.0
-
       - name: Build and test
         run: >
           ./mvnw --batch-mode --update-snapshots verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          server-id: github
+          server-username: MAVEN_USER
+          server-password: MAVEN_TOKEN
           distribution: temurin
           java-version: ${{ inputs.java-version }}
           cache: maven
@@ -31,6 +34,7 @@ jobs:
         env:
           GITHUB_CI_USER: MhikesCI
           GITHUB_CI_EMAIL: ops@mhikes.com
+
         run: |
           git config --global user.name "$GITHUB_CI_USER"
           git config --global user.email "$GITHUB_CI_EMAIL"
@@ -38,6 +42,7 @@ jobs:
       - name: Publish package to GitHub Packages
         id: build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USER: ${{ vars.MAVEN_USER }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
         run: |
           ./mvnw --batch-mode release:prepare release:perform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
           java-version: ${{ inputs.java-version }}
           cache: maven
 
-      - name: Configure package repository credentials
-        uses: s4u/maven-settings-action@v3.1.0
-
       - name: Configure Git user
         env:
           GITHUB_CI_USER: MhikesCI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,26 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.release-branch }}"
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
           cache: maven
 
-      - name: Configure Nexus credentials
-        uses: s4u/maven-settings-action@v2.6.0
-        with:
-          servers: |
-            [
-              {"id": "mhikes-snapshots", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"},
-              {"id": "mhikes-releases", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"},
-              {"id": "old-mhikes-releases", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"}
-            ]
+      - name: Configure package repository credentials
+        uses: s4u/maven-settings-action@v3.1.0
 
       - name: Configure Git user
         env:
@@ -45,11 +38,9 @@ jobs:
           git config --global user.name "$GITHUB_CI_USER"
           git config --global user.email "$GITHUB_CI_EMAIL"
 
-      - name: Build, test, and push to Nexus
+      - name: Publish package to GitHub Packages
         id: build
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B release:clean
-          mvn -B release:prepare
-          mvn -B release:perform
+          ./mvnw --batch-mode release:prepare release:perform

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,32 +7,27 @@ on:
         required: true
         type: string
 
-
-
 jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
           cache: maven
+          # Default:
+          # cache-dependency-path: '**/pom.xml'
 
-      - name: Configure Nexus credentials
-        uses: s4u/maven-settings-action@v2.6.0
-        with:
-          servers: |
-            [
-              {"id": "mhikes-snapshots", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"},
-              {"id": "mhikes-releases", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"},
-              {"id": "old-mhikes-releases", "username": "github-actions", "password": "${{ secrets.MHIKES_NEXUS }}"}
-            ]
+      - name: Configure package repository credentials
+        uses: s4u/maven-settings-action@v3.1.0
 
-      - name: Build, test, and push to Nexus
+      - name: Publish package to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B -U deploy
+          ./mvnw --batch-mode --update-snapshots deploy

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
+          server-id: github
+          server-username: MAVEN_USER
+          server-password: MAVEN_TOKEN
           distribution: temurin
           java-version: ${{ inputs.java-version }}
           cache: maven
@@ -25,6 +28,7 @@ jobs:
 
       - name: Publish package to GitHub Packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USER: ${{ vars.MAVEN_USER }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
         run: |
           ./mvnw --batch-mode --update-snapshots deploy

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -23,9 +23,6 @@ jobs:
           # Default:
           # cache-dependency-path: '**/pom.xml'
 
-      - name: Configure package repository credentials
-        uses: s4u/maven-settings-action@v3.1.0
-
       - name: Publish package to GitHub Packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,148 @@
+# java-workflows
+
+These actions provide an automated way to build and publish Java projects using Maven.
+Packages are deployed on Github Packages.
+
+
+## Release workflow: 
+This action provides an automated way to build and publish Java releases of the project using Maven, to github packages.
+
+Usage: 
+```yaml
+jobs:
+  release:
+    uses: easymountain-mhikes/java-workflows/.github/workflows/release.yml@v2
+    with:
+      java-version: 21
+      release-branch: main
+    secrets: inherit
+```
+
+## Snapshots workflow:
+This action provides an automated way to build and publish Java snapshots of the project using Maven, to github packages.
+
+Usage: 
+```yaml
+jobs:
+  snapshot:
+    uses: easymountain-mhikes/java-workflows/.github/workflows/snapshot.yml@v2
+    with:
+      java-version: 21
+    secrets: inherit
+```
+
+## Pull Request workflow:
+
+This action provides an automated way to build and test Java projects using Maven, ie. when creating a pull request.
+The build jars are uploaded as artifacts.
+
+Usage: 
+```yaml
+jobs:
+  build:
+    uses: easymountain-mhikes/java-workflows/.github/workflows/pull_request.yml@v2
+    with:
+      java-version: 21
+    secrets: inherit
+```
+
+
+## Access to the maven packages
+
+You'll need to create a [personal access](https://github.com/settings/tokens) token with the `read:packages` scope and add it to your maven settings in `~/.m2/settings.xml` as following:
+
+If you need to publish to the repository manually, you can also add the `write:packages` scope to your token.
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>GITHUB-USERNAME</username>
+      <password>GITHUB-TOKEN</password>
+    </server>
+  </servers>
+</settings>
+
+## Configuration of the projects to properly handle GitHub packages
+
+For more information on how to configure your project to use GitHub packages, please refer to the [GitHub documentation](https://docs.github.com/fr/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry).
+
+
+To download dependencies from GitHub packages, you can either add the following configuration to your `pom.xml` file, or to your `~/.m2/settings.xml`:
+
+```xml
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/easymountain-mhikes/*</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+```
+
+In order to publish your project to GitHub packages, you need to add the following configuration to your `pom.xml` file, changing the REPOSITORY placeholder with the name of your repository:
+
+```xml
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/easymountain-mhikes/REPOSITORY</url>
+        </repository>
+    </distributionManagement>
+```
+
+## Releasing a new version of the workflows
+
+Workflows should be referenced with their version, e.g. `@v2` or `@2.0`, to ensure that the workflow is not broken by changes in the main branch.
+
+Unfortunately, these were referenced early in the projects as 
+```yaml
+  uses: easymountain-mhikes/java-workflows/.github/workflows/pull_request.yml@main
+```
+This should be changed to `@v2` or `@2.0` in the future, but for now, we needed to release a new version of the workflow to ensure that the workflow is not broken by changes in the main branch.
+These changed are on the branch `github-repository`, which is the branch that is used to release new versions of the workflow. This branch should be merge to the main branch whenever it's possible.
+
+Once the main branch is stable, we can release a new version of the workflow by creating a new tag.
+
+```bash
+# If the v2 tag already exists, delete it
+git tag -d v2
+
+# Create the tags
+git tag -a v2 -m "Release v2.0"
+git tag -a v2.0 -m "Release v2.0"
+
+# Push the tags to the remote repository
+git push -f origin v2
+git push origin v2.0
+```
+
+## Manual release
+
+```bash
+./mvnw --batch-mode release:clean release:prepare release:perform
+```
+
+This command will perform the following operations:
+
+- Check that there are no SNAPSHOT dependencies
+- Build the project and verify that the tests pass
+- Change the version from x.y.z-SNAPSHOT to x.y.z
+- Create a commit for this change (with the message [maven-release-plugin] prepare release ...)
+- Push this commit to GitHub
+- Create a Git tag in the format artifactId-x.y.z
+- Push this tag to GitHub
+- Change the version from x.y.z to x.y.z+1-SNAPSHOT
+- Create a commit for this change (with the message [maven-release-plugin] prepare for next development iteration)
+- Push this commit to GitHub
+- Push the packages to GitHub Packages
+
+You may need to delete any tag / release / package that was created by the previous command, if it was already released on the CI.


### PR DESCRIPTION
Dependencies are now downloaded though  personal token (classic) to be able to access packages from other repositories in github actions. (cf. https://docs.github.com/fr/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages)
